### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ http://www.zillow.com/howto/api/APIOverview.htm
 - GetMonthlyPayments
 - CalculateMonthlyPaymentsAdvanced
 - CalculateAffordability
+
+
+Test out this API on [RapidAPI](https://rapidapi.com/package/Zillow/functions?utm_source=ZillowGitHub&utm_medium=button)


### PR DESCRIPTION
Hey! I've added a link in your README to Zillow's functions page in RapidAPI. I've done this for a few Zillow SDKs to help those who are reading the READMEs, understand and test the API before use.